### PR TITLE
Standardize About the Author section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,13 +152,17 @@ dotnet pack src/ -c Release
 
 ## 👋 About the Author
 
-**Made with ❤️ by [Bruno Capuano (ElBruno)](https://github.com/elbruno)**
+Hi! I'm **ElBruno** 🧡, a passionate developer and content creator exploring AI, .NET, and modern development practices.
 
-- 📝 **Blog**: [elbruno.com](https://elbruno.com)
-- 📺 **YouTube**: [youtube.com/elbruno](https://youtube.com/elbruno)
-- 🔗 **LinkedIn**: [linkedin.com/in/elbruno](https://linkedin.com/in/elbruno)
-- 𝕏 **Twitter**: [twitter.com/elbruno](https://twitter.com/elbruno)
-- 🎙️ **Podcast**: [notienenombre.com](https://notienenombre.com)
+**Made with ❤️ by [ElBruno](https://github.com/elbruno)**
+
+If you like this project, consider following my work across platforms:
+
+- 📻 **Podcast**: [No Tienen Nombre](https://notienenombre.com) — Spanish-language episodes on AI, development, and tech culture
+- 💻 **Blog**: [ElBruno.com](https://elbruno.com) — Deep dives on embeddings, RAG, .NET, and local AI
+- 📺 **YouTube**: [youtube.com/elbruno](https://www.youtube.com/elbruno) — Demos, tutorials, and live coding
+- 🔗 **LinkedIn**: [@elbruno](https://www.linkedin.com/in/elbruno/) — Professional updates and insights
+- 𝕏 **Twitter**: [@elbruno](https://www.x.com/elbruno/) — Quick tips, releases, and tech news
 
 ---
 


### PR DESCRIPTION
## Summary\n- standardize the README About the Author section to the canonical ElBruno content\n- update the social links to the exact canonical URLs\n\nFixes #31